### PR TITLE
Inspector library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ but also a wrapper to make it easier to use it with Nelua.
 * `fs` - Cross platform file system library, you can use manage files and directories.
 * `json` - Parse JSON into Nelua records, made in pure Nelua.
 * `nester` - Minimal unit testing framework inspired by [lester](https://github.com/edubart/lester).
+* `inspector` - Function module which receives any value and returns the contents as a string, inspired by [inspect.lua](https://github.com/kikito/inspect.lua/)
 
 # Examples
 

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -54,6 +54,11 @@ local a_function = #[concept(function(attr) return attr.type.is_function end)]#
 
 -- specialized inspector functions
 local function inspect_function_value(value: a_function, ctx: string <comptime>): string
+  local function fn_hex_ptr(callback: auto)
+    local cb_str <close> = tostring(callback)
+    return cb_str:gsub('function: ', '', 1)
+  end
+
   ## if ctx.value == 'field' then
     ## local type_fn = ' --[[ ' .. inspect_procedure_value(value) .. ' ]]'
 
@@ -61,14 +66,14 @@ local function inspect_function_value(value: a_function, ctx: string <comptime>)
       return tostring (#['nilptr' .. type_fn]#)
     else
       local sb: stringbuilder <close>
-      local vl <close> = tostring(value):gsub('function: ', '', 1)
+      local vl <close> = fn_hex_ptr(value)
       sb:write(vl, #[type_fn]#)
       return tostring(sb)
     end
 
   ## elseif ctx.value == 'array element' then
     local sb: stringbuilder <close>
-    local vl <close> = tostring(value):gsub('function: ', '', 1)
+    local vl <close> = fn_hex_ptr(value)
     sb:write(vl)
     return tostring(sb)
 

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -4,7 +4,7 @@ The inspector module.
 This module it's a function that receives any value and
 returns the whole content of the passed value as a string.
 
-Inspired by the [inspect](https://github.com/kikito/inspect.lua/) library
+Inspired by the [inspect.lua](https://github.com/kikito/inspect.lua/) library
 
 ## Usage
 

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -1,9 +1,41 @@
---[[
+--[=[
 The inspector module.
 
 This module it's a function that receives any value and
 returns the whole content of the passed value as a string.
+
+Inspired by the [inspect](https://github.com/kikito/inspect.lua/) library
+
+## Usage
+
+Copy `inspector.nelua` file to a project and require it, then just
+call the `inspector` function passing the value to be inspected:
+
+```lua
+require 'inspector' -- note: `local inspector = require "inspector"` it's also supported.
+
+local vec2 = @record{
+  x: number,
+  y: number
+}
+
+local position: vec2 = { 2, 3 }
+
+-- Just call inspector function passing the value to be inspected (it can be anything).
+-- note: if you're not using GC, then you must free the value, otherwise it'll leak.
+local pos_contents <close> = inspector(position)
+
+-- print the inspected position
+print(pos_contents)
+
+--[[ output:
+(@vec2){
+  x = 2.0_f64,
+  y = 3.0_f64,
+}
 ]]
+```
+]=]
 
 require 'string'
 local stringbuilder = require 'stringbuilder'
@@ -226,7 +258,7 @@ local function inspect_array_value(value: a_array, sb: *stringbuilder)
   MACRO_inspect_array_value!(value, 'inspect_array_value', sb)
 end
 
-
+-- The inspector function, pass any value and the contents will be returned as a string (which should be freed).
 global function inspector(value: auto): string
   local sb: stringbuilder <close>
 

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -35,6 +35,11 @@ local short_suffixes = {
   float64 = '_f64',
   float128 = '_f128',
 }
+
+local function inspect_procedure_value(value)
+  static_assert(value.type.is_procedure, 'value is not a procedure!')
+  return tostring(value.type)
+end
 ]]
 
 -- concepts
@@ -45,8 +50,33 @@ local a_record_value = #[concept(function(attr) return attr.type.is_record end)]
 local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
 local a_pointer = #[concept(function(attr) return attr.type.is_pointer end)]#
 local a_stringy = #[concept(function(attr) return attr.type.is_cstring or attr.type.is_string end)]#
+local a_function = #[concept(function(attr) return attr.type.is_function end)]#
 
 -- specialized inspector functions
+local function inspect_function_value(value: a_function, ctx: string <comptime>): string
+  ## if ctx.value == 'field' then
+    ## local type_fn = ' --[[ ' .. inspect_procedure_value(value) .. ' ]]'
+
+    if value == nilptr then
+      return tostring (#['nilptr' .. type_fn]#)
+    else
+      local sb: stringbuilder <close>
+      local vl <close> = tostring(value):gsub('function: ', '', 1)
+      sb:write(vl, #[type_fn]#)
+      return tostring(sb)
+    end
+
+  ## elseif ctx.value == 'array element' then
+    local sb: stringbuilder <close>
+    local vl <close> = tostring(value):gsub('function: ', '', 1)
+    sb:write(vl)
+    return tostring(sb)
+
+  ## else
+    return tostring (#[inspect_procedure_value(value)]#)
+  ## end
+end
+
 local function inspect_pointer_value(value: a_pointer): string
   local sb: stringbuilder <close>
   sb:write(value, #[' --[[ @' .. tostring(value.type) .. ' ]]']#)
@@ -117,6 +147,10 @@ end
         ## if value.type.subtype.is_stringy then
           in inspect_stringy_value(#[value]#[i])
 
+        ## elseif value.type.subtype.is_function then
+          in inspect_function_value(#[value]#[i], 'array element')
+
+
         ## elseif not value.type.subtype.is_aggregate then
           in non_aggregate_value(#[value]#[i], false)
 
@@ -167,6 +201,9 @@ local function inspect_record_value(value: a_record_value, level: integer, use_t
       ## if field.type.is_stringy then
         in inspect_stringy_value(value.#|field.name|#)
 
+      ## elseif field.type.is_function then
+        in inspect_function_value(value.#|field.name|#, 'field')
+
       ## elseif not field.type.is_aggregate then
         in non_aggregate_value(value.#|field.name|#, true)
 
@@ -203,6 +240,9 @@ global function inspector(value: auto): string
   ## if value.type.is_stringy then
     return inspect_stringy_value(value)
 
+  ## elseif value.type.is_procedure then
+    return tostring(#[inspect_procedure_value(value)]#)
+
   ## elseif not value.type.is_aggregate then
     return non_aggregate_value(value, true)
 
@@ -215,5 +255,5 @@ global function inspector(value: auto): string
     ## end
   ## end
 
-  return 'Unknown'
+  return tostring('Unknown')
 end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -1,0 +1,33 @@
+--[[
+The inspector module.
+
+This module it's a function that receives anything and
+returns the whole content of the passed value as a string.
+]]
+
+require 'string'
+local stringbuilder = require 'stringbuilder'
+
+-- meta-utils
+##[[
+local function is_simple_primitive(type)
+  return type.is_boolean or type.is_scalar or type.is_stringy
+end
+]]
+
+-- concepts
+local a_simple_primitive: type = #[concept(function(attr)
+  return is_simple_primitive(attr.type)
+end)]#
+
+-- more specialized inspector functions
+local function inspect_simple(value: a_simple_primitive): string
+  return tostring(value)
+end
+
+-- the inspector module
+global function inspector(value: auto): string
+  ## if is_simple_primitive(value.type) then
+    return inspect_simple(value)
+  ## end
+end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -259,7 +259,10 @@ end
 
 -- the inspector module
 global function inspector(value: auto): string
-  ## if value.type.is_stringy then
+  ## if value.type.is_type then
+    return tostring(#['@'..value.value:typedesc()]#)
+
+  ## elseif value.type.is_stringy then
     return inspect_stringy_value(value)
 
   ## elseif value.type.is_union then

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -41,6 +41,7 @@ local short_suffixes = {
 local a_simple_primitive: type = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
 local a_array = #[concept(function(attr) return attr.type.is_array end)]#
 local a_enum_value = #[concept(function(attr) return attr.type.is_enum end)]#
+local a_record_value = #[concept(function(attr) return attr.type.is_record end)]#
 local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
 
 -- more specialized inspector functions
@@ -109,6 +110,30 @@ local function inspect_array(value: a_array): string
   return tostring(sb)
 end
 
+local function inspect_record_value(value: a_record_value): string
+  local sb: stringbuilder <close>
+
+  sb:write(#['(@' .. tostring(value.type) .. '){\n']#)
+
+  ## for _, field in ipairs(value.type.fields) do
+    ## local indentation = '  '
+    sb:write(#[indentation .. field.name .. ' = ']#)
+
+    local value_str <close> = (do
+      ## if not field.type.is_aggregate then
+        in non_aggregate_value(value.#|field.name|#)
+      ## else
+        in 'TODO'
+      ## end
+    end)
+
+    sb:write(value_str, ',\n')
+  ## end
+
+  sb:write('}')
+
+  return tostring(sb)
+end
 
 -- the inspector module
 global function inspector(value: auto): string
@@ -118,6 +143,9 @@ global function inspector(value: auto): string
   ## else
     ## if value.type.is_string then
       return inspect_simple_value(value)
+
+    ## elseif value.type.is_record then
+      return inspect_record_value(value)
 
     ## elseif value.type.is_array then
       return inspect_array(value)

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -125,7 +125,7 @@ local function inspect_enum_value(value: a_enum_value): string
     end
   ## end
 
-  sb:writef(#[' --[[ = %d'.. short_suffixes[value.type.subtype.name] ..' ]]']#, value)
+  sb:writef(#[' --[[ %d'.. short_suffixes[value.type.subtype.name] ..' ]]']#, value)
 
   return tostring(sb)
 end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -43,9 +43,16 @@ local a_array = #[concept(function(attr) return attr.type.is_array end)]#
 local a_enum_value = #[concept(function(attr) return attr.type.is_enum end)]#
 local a_record_value = #[concept(function(attr) return attr.type.is_record end)]#
 local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
+local a_pointer = #[concept(function(attr) return attr.type.is_pointer end)]#
 local a_stringy = #[concept(function(attr) return attr.type.is_cstring or attr.type.is_string end)]#
 
 -- specialized inspector functions
+local function inspect_pointer_value(value: a_pointer): string
+  local sb: stringbuilder <close>
+  sb:write(value, #[' --[[ @' .. tostring(value.type) .. ' ]]']#)
+  return tostring(sb)
+end
+
 local function inspect_stringy_value(value: a_stringy): string
   local sb: stringbuilder <close>
   sb:write('"', value, '"')
@@ -90,6 +97,9 @@ local function non_aggregate_value(value: a_non_aggregate, use_suffix: boolean <
 
   ## elseif is_simple_primitive(value.type) then
     return inspect_simple_value(value, use_suffix)
+
+  ## elseif value.type.is_pointer then
+    return inspect_pointer_value(value)
 
   ## else
     return 'Unknown'

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -13,37 +13,48 @@ local stringbuilder = require 'stringbuilder'
 local function is_simple_primitive(type)
   return type.is_boolean or type.is_scalar or type.is_stringy
 end
+
+local short_suffixes = {
+  integer = '_i',
+  uinteger = '_u',
+  number = '_n',
+  byte = '_b',
+  isize = '_is',
+  int8 = '_i8',
+  int16 = '_i16',
+  int32 = '_i32',
+  int64 = '_i64',
+  int128 = '_i128',
+  usize = '_us',
+  uint8 = '_u8',
+  uint16 = '_u16',
+  uint32 = '_u32',
+  uint64 = '_u64',
+  uint128 = '_u128',
+  float32 = '_f32',
+  float64 = '_f64',
+  float128 = '_f128',
+}
 ]]
 
 -- concepts
 local a_simple_primitive: type = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
 local a_array = #[concept(function(attr) return attr.type.is_array end)]#
 local a_enum_value = #[concept(function(attr) return attr.type.is_enum end)]#
+local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
 
 -- more specialized inspector functions
-local function inspect_simple(value: a_simple_primitive): string
-  return tostring(value)
+local function inspect_simple_value(value: a_simple_primitive): string
+  ## local type_suffix = short_suffixes[value.type.name]
+
+  ## if type_suffix then
+    local value_str <close> = tostring(value)
+    return value_str .. #[type_suffix]#
+  ## else
+    return tostring(value)
+  ## end
 end
 
-local function inspect_array(value: a_array): string
-  local sb: stringbuilder <close>
-
-  sb:writef("(@%s){ ", #[tostring(value.type)]#)
-
-  for i = 0, < #value do
-    if i < #value - 1 then
-      sb:write(value[i], ', ')
-    else
-      sb:write(value[i])
-    end
-  end
-
-  sb:write(" }")
-
-  return tostring(sb)
-end
-
--- TODO: needs serious improvement
 local function inspect_enum_value(value: a_enum_value): string
   local sb: stringbuilder <close>
 
@@ -57,20 +68,61 @@ local function inspect_enum_value(value: a_enum_value): string
     end
   ## end
 
-  sb:writef(#[' --[[ = %d_'.. tostring(value.type.subtype) ..' ]]']#, value)
+  sb:writef(#[' --[[ = %d'.. short_suffixes[value.type.subtype.name] ..' ]]']#, value)
 
   return tostring(sb)
 end
 
--- the inspector module
-global function inspector(value: auto): string
+local function non_aggregate_value(value: a_non_aggregate): string
   ## if value.type.is_enum then
     return inspect_enum_value(value)
 
-  ## elseif value.type.is_array then
-    return inspect_array(value)
-
   ## elseif is_simple_primitive(value.type) then
-    return inspect_simple(value)
+    return inspect_simple_value(value)
+
   ## end
+end
+
+local function inspect_array(value: a_array): string
+  local sb: stringbuilder <close>
+
+  sb:write(#['(@' .. tostring(value.type) .. '){ ']#)
+
+  for i = 0, < #value do
+    local value_str <close> = (do
+      ## if not value.type.subtype.is_aggregate then
+        in non_aggregate_value(value[i])
+      ## else
+        in 'TODO'
+      ## end
+    end)
+
+    if i < #value - 1 then
+      sb:write(value_str, ', ')
+    else
+      sb:write(value_str)
+    end
+  end
+
+  sb:write(" }")
+
+  return tostring(sb)
+end
+
+
+-- the inspector module
+global function inspector(value: auto): string
+  ## if not value.type.is_aggregate then
+    return non_aggregate_value(value)
+
+  ## else
+    ## if value.type.is_string then
+      return inspect_simple_value(value)
+
+    ## elseif value.type.is_array then
+      return inspect_array(value)
+    ## end
+  ## end
+
+  return 'Unknown'
 end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -12,7 +12,7 @@ Copy `inspector.nelua` file to a project and require it, then just
 call the `inspector` function passing the value to be inspected:
 
 ```lua
-require 'inspector' -- note: `local inspector = require "inspector"` it's also supported.
+require 'inspector'
 
 local vec2 = @record{
   x: number,

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -79,7 +79,11 @@ end
 
 local function inspect_pointer_value(value: a_pointer): string
   local sb: stringbuilder <close>
-  sb:write(value, #[' --[[ @' .. tostring(value.type) .. ' ]]']#)
+  if value then
+    sb:write(value, #[' --[[ @' .. tostring(value.type) .. ' ]]']#)
+  else
+    sb:write(#['nilptr --[[ @' .. tostring(value.type) .. ' ]]']#)
+  end
   return tostring(sb)
 end
 
@@ -130,6 +134,9 @@ local function non_aggregate_value(value: a_non_aggregate, use_suffix: boolean <
 
   ## elseif value.type.is_pointer then
     return inspect_pointer_value(value)
+
+  ## elseif value.type.is_nilptr then
+    return 'nilptr'
 
   ## else
     return 'Unknown'

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -38,13 +38,23 @@ local short_suffixes = {
 ]]
 
 -- concepts
-local a_simple_primitive: type = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
+local a_simple_primitive = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
 local a_array = #[concept(function(attr) return attr.type.is_array end)]#
 local a_enum_value = #[concept(function(attr) return attr.type.is_enum end)]#
 local a_record_value = #[concept(function(attr) return attr.type.is_record end)]#
 local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
+local a_stringy = #[concept(function(attr) return attr.type.is_cstring or attr.type.is_string end)]#
 
--- more specialized inspector functions
+-- specialized inspector functions
+local function inspect_stringy_value(value: a_stringy): string
+  local sb: stringbuilder <close>
+  sb:write('"', value, '"')
+  ## if value.type.is_cstring then
+    sb:write(' --[[ @cstring ]]')
+  ## end
+  return tostring(sb)
+end
+
 local function inspect_simple_value(value: a_simple_primitive, use_suffix: boolean <comptime>): string
   ## local type_suffix = short_suffixes[value.type.name]
 
@@ -80,6 +90,9 @@ local function non_aggregate_value(value: a_non_aggregate, use_suffix: boolean <
 
   ## elseif is_simple_primitive(value.type) then
     return inspect_simple_value(value, use_suffix)
+
+  ## else
+    return 'Unknown'
   ## end
 end
 
@@ -91,17 +104,19 @@ end
 
     for i = 0, < #(#[value]#) do
       local value_str <close> = (do
-        ## if not value.type.subtype.is_aggregate then
+        ## if value.type.subtype.is_stringy then
+          in inspect_stringy_value(#[value]#[i])
+
+        ## elseif not value.type.subtype.is_aggregate then
           in non_aggregate_value(#[value]#[i], false)
 
-        ## elseif value.type.subtype.is_array then
-            in #|inspect_array_value_fn_name|#(#[value]#[i])
-
-        ## elseif value.type.subtype.is_record then
-          in inspect_record_value(#[value]#[i], 0, false)
-
         ## else
-          in 'TODO'
+          ## if value.type.subtype.is_record then
+            in inspect_record_value(#[value]#[i], 0, false)
+
+          ## elseif value.type.subtype.is_array then
+            in #|inspect_array_value_fn_name|#(#[value]#[i])
+          ## end
         ## end
       end)
 
@@ -139,17 +154,21 @@ local function inspect_record_value(value: a_record_value, level: integer, use_t
     sb:write(indentation_plus, #[field.name .. ' = ']#)
 
     local value_str <close> = (do
-      ## if not field.type.is_aggregate then
-        in non_aggregate_value(value.#|field.name|#, true)
-      ## else
-        ## if field.type.is_array then
-          in inspect_array_value(value.#|field.name|#)
+      ## if field.type.is_stringy then
+        in inspect_stringy_value(value.#|field.name|#)
 
-        ## elseif field.type.is_record then
+      ## elseif not field.type.is_aggregate then
+        in non_aggregate_value(value.#|field.name|#, true)
+
+      ## else
+        ## if field.type.is_record then
           in inspect_record_value(value.#|field.name|#, (level + 1), true)
 
+        ## elseif field.type.is_array then
+          in inspect_array_value(value.#|field.name|#)
+
         ## else
-          in 'TODO'
+          in 'Unknown'
         ## end
       ## end
     end)
@@ -171,14 +190,14 @@ end
 
 -- the inspector module
 global function inspector(value: auto): string
-  ## if not value.type.is_aggregate then
+  ## if value.type.is_stringy then
+    return inspect_stringy_value(value)
+
+  ## elseif not value.type.is_aggregate then
     return non_aggregate_value(value, true)
 
   ## else
-    ## if value.type.is_string then
-      return inspect_simple_value(value, false)
-
-    ## elseif value.type.is_record then
+    ## if value.type.is_record then
       return inspect_record_value(value, 0, true)
 
     ## elseif value.type.is_array then

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -16,13 +16,9 @@ end
 ]]
 
 -- concepts
-local a_simple_primitive: type = #[concept(function(attr)
-  return is_simple_primitive(attr.type)
-end)]#
-
-local a_array = #[concept(function(attr)
-  return attr.type.is_array
-end)]#
+local a_simple_primitive: type = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
+local a_array = #[concept(function(attr) return attr.type.is_array end)]#
+local a_enum_value = #[concept(function(attr) return attr.type.is_enum end)]#
 
 -- more specialized inspector functions
 local function inspect_simple(value: a_simple_primitive): string
@@ -47,11 +43,34 @@ local function inspect_array(value: a_array): string
   return tostring(sb)
 end
 
+-- TODO: needs serious improvement
+local function inspect_enum_value(value: a_enum_value): string
+  local sb: stringbuilder <close>
+
+  sb:write(#[tostring(value.type) .. '.']#)
+
+  -- Note: this unrolls various `if`s, just to find and write to sb the right enum field
+  -- correspondent to the value
+  ## for _, field in ipairs(value.type.fields) do
+    if value == #[field.value]# then
+      sb:write(#[field.name]#)
+    end
+  ## end
+
+  sb:writef(#[' --[[ = %d_'.. tostring(value.type.subtype) ..' ]]']#, value)
+
+  return tostring(sb)
+end
+
 -- the inspector module
 global function inspector(value: auto): string
-  ## if is_simple_primitive(value.type) then
-    return inspect_simple(value)
+  ## if value.type.is_enum then
+    return inspect_enum_value(value)
+
   ## elseif value.type.is_array then
     return inspect_array(value)
+
+  ## elseif is_simple_primitive(value.type) then
+    return inspect_simple(value)
   ## end
 end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -9,7 +9,7 @@ require 'string'
 local stringbuilder = require 'stringbuilder'
 
 -- meta-utils
-##[[
+##[=[
 local function is_simple_primitive(type)
   return type.is_boolean or type.is_scalar or type.is_stringy
 end
@@ -40,7 +40,7 @@ local function inspect_procedure_value(value)
   static_assert(value.type.is_procedure, 'value is not a procedure!')
   return tostring(value.type)
 end
-]]
+]=]
 
 -- concepts
 local a_simple_primitive = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
@@ -51,8 +51,13 @@ local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggrega
 local a_pointer = #[concept(function(attr) return attr.type.is_pointer end)]#
 local a_stringy = #[concept(function(attr) return attr.type.is_cstring or attr.type.is_string end)]#
 local a_function = #[concept(function(attr) return attr.type.is_function end)]#
+local a_union = #[concept(function(attr) return attr.type.is_union end)]#
 
 -- specialized inspector functions
+local function inspect_union_value(value: a_union)
+  return tostring(#['(@' .. tostring(value.type) .. ")() --[[ @" .. value.type:typedesc() .. " ]]"]#)
+end
+
 local function inspect_function_value(value: a_function, ctx: string <comptime>): string
   local function fn_hex_ptr(callback: auto)
     local cb_str <close> = tostring(callback)
@@ -162,6 +167,8 @@ end
         ## elseif value.type.subtype.is_function then
           in inspect_function_value(#[value]#[i], 'array element')
 
+        ## elseif value.type.subtype.is_union then
+          in inspect_union_value(#[value]#[i])
 
         ## elseif not value.type.subtype.is_aggregate then
           in non_aggregate_value(#[value]#[i], false)
@@ -216,6 +223,9 @@ local function inspect_record_value(value: a_record_value, level: integer, use_t
       ## elseif field.type.is_function then
         in inspect_function_value(value.#|field.name|#, 'field')
 
+      ## elseif field.type.is_union then
+        in inspect_union_value(value.#|field.name|#)
+
       ## elseif not field.type.is_aggregate then
         in non_aggregate_value(value.#|field.name|#, true)
 
@@ -251,6 +261,9 @@ end
 global function inspector(value: auto): string
   ## if value.type.is_stringy then
     return inspect_stringy_value(value)
+
+  ## elseif value.type.is_union then
+    return inspect_union_value(value)
 
   ## elseif value.type.is_procedure then
     return tostring(#[inspect_procedure_value(value)]#)

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -45,10 +45,10 @@ local a_record_value = #[concept(function(attr) return attr.type.is_record end)]
 local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
 
 -- more specialized inspector functions
-local function inspect_simple_value(value: a_simple_primitive): string
+local function inspect_simple_value(value: a_simple_primitive, use_suffix: boolean <comptime>): string
   ## local type_suffix = short_suffixes[value.type.name]
 
-  ## if type_suffix then
+  ## if type_suffix and use_suffix.value then
     local value_str <close> = tostring(value)
     return value_str .. #[type_suffix]#
   ## else
@@ -74,81 +74,115 @@ local function inspect_enum_value(value: a_enum_value): string
   return tostring(sb)
 end
 
-local function non_aggregate_value(value: a_non_aggregate): string
+local function non_aggregate_value(value: a_non_aggregate, use_suffix: boolean <comptime>): string
   ## if value.type.is_enum then
     return inspect_enum_value(value)
 
   ## elseif is_simple_primitive(value.type) then
-    return inspect_simple_value(value)
-
+    return inspect_simple_value(value, use_suffix)
   ## end
 end
 
-local function inspect_array(value: a_array): string
-  local sb: stringbuilder <close>
+## local function MACRO_inspect_array_value(value, inspect_array_value_fn_name)
+  do
+    local sb: stringbuilder <close>
 
-  sb:write(#['(@' .. tostring(value.type) .. '){ ']#)
+    sb:write(#['(@' .. tostring(value.type) .. '){ ']#)
 
-  for i = 0, < #value do
-    local value_str <close> = (do
-      ## if not value.type.subtype.is_aggregate then
-        in non_aggregate_value(value[i])
-      ## else
-        in 'TODO'
-      ## end
-    end)
+    for i = 0, < #(#[value]#) do
+      local value_str <close> = (do
+        ## if not value.type.subtype.is_aggregate then
+          in non_aggregate_value(#[value]#[i], false)
 
-    if i < #value - 1 then
-      sb:write(value_str, ', ')
-    else
-      sb:write(value_str)
+        ## elseif value.type.subtype.is_array then
+            in #|inspect_array_value_fn_name|#(#[value]#[i])
+
+        ## elseif value.type.subtype.is_record then
+          in inspect_record_value(#[value]#[i], 0, false)
+
+        ## else
+          in 'TODO'
+        ## end
+      end)
+
+      if i < #value - 1 then
+        sb:write(value_str, ', ')
+      else
+        sb:write(value_str)
+      end
     end
+
+    sb:write(" }")
+
+    MACRO_str_result = tostring(sb)
+  end
+## end
+
+local function inspect_record_value(value: a_record_value, level: integer, use_type_prefix: boolean): string
+  local function inspect_array_value(value: a_array): string
+    local MACRO_str_result: string
+    MACRO_inspect_array_value!(value, 'inspect_array_value')
+    return MACRO_str_result
   end
 
-  sb:write(" }")
-
-  return tostring(sb)
-end
-
-local function inspect_record_value(value: a_record_value): string
   local sb: stringbuilder <close>
 
-  sb:write(#['(@' .. tostring(value.type) .. '){\n']#)
+  if use_type_prefix then
+    sb:write(#['(@' .. tostring(value.type) .. '){\n']#)
+  else
+    sb:write('{\n')
+  end
+
+  local indentation_plus <close> = string.rep('  ', level + 1)
 
   ## for _, field in ipairs(value.type.fields) do
-    ## local indentation = '  '
-    sb:write(#[indentation .. field.name .. ' = ']#)
+    sb:write(indentation_plus, #[field.name .. ' = ']#)
 
     local value_str <close> = (do
       ## if not field.type.is_aggregate then
-        in non_aggregate_value(value.#|field.name|#)
+        in non_aggregate_value(value.#|field.name|#, true)
       ## else
-        in 'TODO'
+        ## if field.type.is_array then
+          in inspect_array_value(value.#|field.name|#)
+
+        ## elseif field.type.is_record then
+          in inspect_record_value(value.#|field.name|#, (level + 1), true)
+
+        ## else
+          in 'TODO'
+        ## end
       ## end
     end)
 
     sb:write(value_str, ',\n')
   ## end
 
-  sb:write('}')
+  local indentation <close> = string.rep('  ', level)
+  sb:write(indentation, '}')
 
   return tostring(sb)
+end
+
+local function inspect_array_value(value: a_array): string
+  local MACRO_str_result: string
+  MACRO_inspect_array_value!(value, 'inspect_array_value')
+  return MACRO_str_result
 end
 
 -- the inspector module
 global function inspector(value: auto): string
   ## if not value.type.is_aggregate then
-    return non_aggregate_value(value)
+    return non_aggregate_value(value, true)
 
   ## else
     ## if value.type.is_string then
-      return inspect_simple_value(value)
+      return inspect_simple_value(value, false)
 
     ## elseif value.type.is_record then
-      return inspect_record_value(value)
+      return inspect_record_value(value, 0, true)
 
     ## elseif value.type.is_array then
-      return inspect_array(value)
+      return inspect_array_value(value)
     ## end
   ## end
 

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -54,11 +54,11 @@ local a_function         = #[concept(function(attr) return attr.type.is_function
 local a_union            = #[concept(function(attr) return attr.type.is_union end)]#
 
 -- specialized inspector functions
-local function inspect_union_value(value: a_union)
-  return tostring(#['(@' .. tostring(value.type) .. ")() --[[ @" .. value.type:typedesc() .. " ]]"]#)
+local function inspect_union_value(value: a_union, sb: *stringbuilder)
+  sb:write(#['(@' .. tostring(value.type) .. ")() --[[ @" .. value.type:typedesc() .. " ]]"]#)
 end
 
-local function inspect_function_value(value: a_function, ctx: string <comptime>): string
+local function inspect_function_value(value: a_function, ctx: string <comptime>, sb: *stringbuilder)
   local function fn_hex_ptr(callback: auto)
     local cb_str <close> = tostring(callback)
     return cb_str:gsub('function: ', '', 1)
@@ -68,58 +68,47 @@ local function inspect_function_value(value: a_function, ctx: string <comptime>)
     ## local type_fn = ' --[[ ' .. inspect_procedure_value(value) .. ' ]]'
 
     if value == nilptr then
-      return tostring (#['nilptr' .. type_fn]#)
+      sb:write(#['nilptr' .. type_fn]#)
     else
-      local sb: stringbuilder <close>
       local vl <close> = fn_hex_ptr(value)
       sb:write(vl, #[type_fn]#)
-      return tostring(sb)
     end
 
   ## elseif ctx.value == 'array element' then
-    local sb: stringbuilder <close>
     local vl <close> = fn_hex_ptr(value)
     sb:write(vl)
-    return tostring(sb)
 
   ## else
-    return tostring (#[inspect_procedure_value(value)]#)
+    sb:write(#[inspect_procedure_value(value)]#)
   ## end
 end
 
-local function inspect_pointer_value(value: a_pointer): string
-  local sb: stringbuilder <close>
+local function inspect_pointer_value(value: a_pointer, sb: *stringbuilder)
   if value then
     sb:write(value, #[' --[[ @' .. tostring(value.type) .. ' ]]']#)
   else
     sb:write(#['nilptr --[[ @' .. tostring(value.type) .. ' ]]']#)
   end
-  return tostring(sb)
 end
 
-local function inspect_stringy_value(value: a_stringy): string
-  local sb: stringbuilder <close>
+local function inspect_stringy_value(value: a_stringy, sb: *stringbuilder)
   sb:write('"', value, '"')
   ## if value.type.is_cstring then
     sb:write(' --[[ @cstring ]]')
   ## end
-  return tostring(sb)
 end
 
-local function inspect_simple_value(value: a_simple_primitive, use_suffix: boolean <comptime>): string
+local function inspect_simple_value(value: a_simple_primitive, use_suffix: boolean <comptime>, sb: *stringbuilder)
   ## local type_suffix = short_suffixes[value.type.name]
 
   ## if type_suffix and use_suffix.value then
-    local value_str <close> = tostring(value)
-    return value_str .. #[type_suffix]#
+    sb:write(value, #[type_suffix]#)
   ## else
-    return tostring(value)
+    sb:write(value)
   ## end
 end
 
-local function inspect_enum_value(value: a_enum_value): string
-  local sb: stringbuilder <close>
-
+local function inspect_enum_value(value: a_enum_value, sb: *stringbuilder)
   sb:write(#[tostring(value.type) .. '.']#)
 
   -- Note: this unrolls various `if`s, just to find and write to sb the right enum field
@@ -131,79 +120,65 @@ local function inspect_enum_value(value: a_enum_value): string
   ## end
 
   sb:writef(#[' --[[ %d'.. short_suffixes[value.type.subtype.name] ..' ]]']#, value)
-
-  return tostring(sb)
 end
 
-local function non_aggregate_value(value: a_non_aggregate, use_suffix: boolean <comptime>): string
+local function non_aggregate_value(value: a_non_aggregate, use_suffix: boolean <comptime>, sb: *stringbuilder)
   ## if value.type.is_enum then
-    return inspect_enum_value(value)
+    inspect_enum_value(value, sb)
 
   ## elseif is_simple_primitive(value.type) then
-    return inspect_simple_value(value, use_suffix)
+    inspect_simple_value(value, use_suffix, sb)
 
   ## elseif value.type.is_pointer then
-    return inspect_pointer_value(value)
+    inspect_pointer_value(value, sb)
 
   ## elseif value.type.is_nilptr then
-    return 'nilptr'
+    sb:write('nilptr')
 
   ## else
-    return 'Unknown'
+    sb:write('Unknown')
   ## end
 end
 
-## local function MACRO_inspect_array_value(value, inspect_array_value_fn_name)
+## local function MACRO_inspect_array_value(value, inspect_array_value_fn_name, sb)
   do
-    local sb: stringbuilder <close>
-
-    sb:write(#['(@' .. tostring(value.type) .. '){ ']#)
+    #[sb]#:write(#['(@' .. tostring(value.type) .. '){ ']#)
 
     for i = 0, < #(#[value]#) do
-      local value_str <close> = (do
-        ## if value.type.subtype.is_stringy then
-          in inspect_stringy_value(#[value]#[i])
+      ## if value.type.subtype.is_stringy then
+        inspect_stringy_value(#[value]#[i], sb)
 
-        ## elseif value.type.subtype.is_function then
-          in inspect_function_value(#[value]#[i], 'array element')
+      ## elseif value.type.subtype.is_function then
+        inspect_function_value(#[value]#[i], 'array element', sb)
 
-        ## elseif value.type.subtype.is_union then
-          in inspect_union_value(#[value]#[i])
+      ## elseif value.type.subtype.is_union then
+        inspect_union_value(#[value]#[i], sb)
 
-        ## elseif not value.type.subtype.is_aggregate then
-          in non_aggregate_value(#[value]#[i], false)
+      ## elseif not value.type.subtype.is_aggregate then
+        non_aggregate_value(#[value]#[i], false, sb)
 
-        ## else
-          ## if value.type.subtype.is_record then
-            in inspect_record_value(#[value]#[i], 0, false)
+      ## else
+        ## if value.type.subtype.is_record then
+          inspect_record_value(#[value]#[i], 0, false, sb)
 
-          ## elseif value.type.subtype.is_array then
-            in #|inspect_array_value_fn_name|#(#[value]#[i])
-          ## end
+        ## elseif value.type.subtype.is_array then
+          #|inspect_array_value_fn_name|#(#[value]#[i], sb)
         ## end
-      end)
+      ## end
 
       if i < #value - 1 then
-        sb:write(value_str, ', ')
-      else
-        sb:write(value_str)
+        #[sb]#:write(', ')
       end
     end
 
-    sb:write(" }")
-
-    MACRO_str_result = tostring(sb)
+    #[sb]#:write(" }")
   end
 ## end
 
-local function inspect_record_value(value: a_record_value, level: integer, use_type_prefix: boolean): string
-  local function inspect_array_value(value: a_array): string
-    local MACRO_str_result: string
-    MACRO_inspect_array_value!(value, 'inspect_array_value')
-    return MACRO_str_result
+local function inspect_record_value(value: a_record_value, level: integer, use_type_prefix: boolean, sb: *stringbuilder)
+  local function inspect_array_value(value: a_array, sb: *stringbuilder)
+    MACRO_inspect_array_value!(value, 'inspect_array_value', sb)
   end
-
-  local sb: stringbuilder <close>
 
   if use_type_prefix then
     sb:write(#['(@' .. tostring(value.type) .. '){\n']#)
@@ -216,74 +191,71 @@ local function inspect_record_value(value: a_record_value, level: integer, use_t
   ## for _, field in ipairs(value.type.fields) do
     sb:write(indentation_plus, #[field.name .. ' = ']#)
 
-    local value_str <close> = (do
-      ## if field.type.is_stringy then
-        in inspect_stringy_value(value.#|field.name|#)
+    ## if field.type.is_stringy then
+      inspect_stringy_value(value.#|field.name|#, sb)
 
-      ## elseif field.type.is_function then
-        in inspect_function_value(value.#|field.name|#, 'field')
+    ## elseif field.type.is_function then
+      inspect_function_value(value.#|field.name|#, 'field', sb)
 
-      ## elseif field.type.is_union then
-        in inspect_union_value(value.#|field.name|#)
+    ## elseif field.type.is_union then
+      inspect_union_value(value.#|field.name|#, sb)
 
-      ## elseif not field.type.is_aggregate then
-        in non_aggregate_value(value.#|field.name|#, true)
+    ## elseif not field.type.is_aggregate then
+      non_aggregate_value(value.#|field.name|#, true, sb)
+
+    ## else
+      ## if field.type.is_record then
+        inspect_record_value(value.#|field.name|#, (level + 1), true, sb)
+
+      ## elseif field.type.is_array then
+        inspect_array_value(value.#|field.name|#, sb)
 
       ## else
-        ## if field.type.is_record then
-          in inspect_record_value(value.#|field.name|#, (level + 1), true)
-
-        ## elseif field.type.is_array then
-          in inspect_array_value(value.#|field.name|#)
-
-        ## else
-          in 'Unknown'
-        ## end
+        sb:write('Unknown')
       ## end
-    end)
+    ## end
 
-    sb:write(value_str, ',\n')
+    sb:write(',\n')
   ## end
 
   local indentation <close> = string.rep('  ', level)
   sb:write(indentation, '}')
-
-  return tostring(sb)
 end
 
-local function inspect_array_value(value: a_array): string
-  local MACRO_str_result: string
-  MACRO_inspect_array_value!(value, 'inspect_array_value')
-  return MACRO_str_result
+local function inspect_array_value(value: a_array, sb: *stringbuilder)
+  MACRO_inspect_array_value!(value, 'inspect_array_value', sb)
 end
 
--- the inspector module
+
 global function inspector(value: auto): string
+  local sb: stringbuilder <close>
+
   ## if value.type.is_type then
-    return tostring(#['@'..value.value:typedesc()]#)
+    sb:write(#['@'..value.value:typedesc()]#)
 
   ## elseif value.type.is_stringy then
-    return inspect_stringy_value(value)
+    inspect_stringy_value(value, sb)
 
   ## elseif value.type.is_union then
-    return inspect_union_value(value)
+    inspect_union_value(value, sb)
 
   ## elseif value.type.is_procedure then
-    return tostring(#[inspect_procedure_value(value)]#)
+    sb:write(#[inspect_procedure_value(value)]#)
 
   ## elseif not value.type.is_aggregate then
-    return non_aggregate_value(value, true)
+    non_aggregate_value(value, true, sb)
 
   ## else
     ## if value.type.is_record then
-      return inspect_record_value(value, 0, true)
+      inspect_record_value(value, 0, true, sb)
 
     ## elseif value.type.is_array then
-      return inspect_array_value(value)
+      inspect_array_value(value, sb)
 
     ## else
-      return tostring('Unknown')
+      sb:write('Unknown')
     ## end
   ## end
 
+  return tostring(sb)
 end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -20,14 +20,38 @@ local a_simple_primitive: type = #[concept(function(attr)
   return is_simple_primitive(attr.type)
 end)]#
 
+local a_array = #[concept(function(attr)
+  return attr.type.is_array
+end)]#
+
 -- more specialized inspector functions
 local function inspect_simple(value: a_simple_primitive): string
   return tostring(value)
+end
+
+local function inspect_array(value: a_array): string
+  local sb: stringbuilder <close>
+
+  sb:writef("(@%s){ ", #[tostring(value.type)]#)
+
+  for i = 0, < #value do
+    if i < #value - 1 then
+      sb:write(value[i], ', ')
+    else
+      sb:write(value[i])
+    end
+  end
+
+  sb:write(" }")
+
+  return tostring(sb)
 end
 
 -- the inspector module
 global function inspector(value: auto): string
   ## if is_simple_primitive(value.type) then
     return inspect_simple(value)
+  ## elseif value.type.is_array then
+    return inspect_array(value)
   ## end
 end

--- a/inspector.nelua
+++ b/inspector.nelua
@@ -1,7 +1,7 @@
 --[[
 The inspector module.
 
-This module it's a function that receives anything and
+This module it's a function that receives any value and
 returns the whole content of the passed value as a string.
 ]]
 
@@ -44,14 +44,14 @@ end
 
 -- concepts
 local a_simple_primitive = #[concept(function(attr) return is_simple_primitive(attr.type) end)]#
-local a_array = #[concept(function(attr) return attr.type.is_array end)]#
-local a_enum_value = #[concept(function(attr) return attr.type.is_enum end)]#
-local a_record_value = #[concept(function(attr) return attr.type.is_record end)]#
-local a_non_aggregate = #[concept(function(attr) return not attr.type.is_aggregate end)]#
-local a_pointer = #[concept(function(attr) return attr.type.is_pointer end)]#
-local a_stringy = #[concept(function(attr) return attr.type.is_cstring or attr.type.is_string end)]#
-local a_function = #[concept(function(attr) return attr.type.is_function end)]#
-local a_union = #[concept(function(attr) return attr.type.is_union end)]#
+local a_array            = #[concept(function(attr) return attr.type.is_array end)]#
+local a_enum_value       = #[concept(function(attr) return attr.type.is_enum end)]#
+local a_record_value     = #[concept(function(attr) return attr.type.is_record end)]#
+local a_non_aggregate    = #[concept(function(attr) return not attr.type.is_aggregate end)]#
+local a_pointer          = #[concept(function(attr) return attr.type.is_pointer end)]#
+local a_stringy          = #[concept(function(attr) return attr.type.is_cstring or attr.type.is_string end)]#
+local a_function         = #[concept(function(attr) return attr.type.is_function end)]#
+local a_union            = #[concept(function(attr) return attr.type.is_union end)]#
 
 -- specialized inspector functions
 local function inspect_union_value(value: a_union)
@@ -280,8 +280,10 @@ global function inspector(value: auto): string
 
     ## elseif value.type.is_array then
       return inspect_array_value(value)
+
+    ## else
+      return tostring('Unknown')
     ## end
   ## end
 
-  return tostring('Unknown')
 end

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,8 @@ test: \
 	test-json \
 	test-ffi \
 	test-backtrace \
-	test-nester
+	test-nester \
+	test-inspector
 
 test-fs:
 	$(NELUARUN) fs_test.nelua
@@ -24,3 +25,6 @@ test-ffi:
 
 test-nester:
 	$(NELUARUN) nester_test.nelua
+
+test-inspector:
+	$(NELUARUN) inspector_test.nelua

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -1,0 +1,37 @@
+require 'inspector'
+require 'nester'
+
+nester.describe("inspector", function()
+  nester.describe("primitives", function()
+    nester.describe("simple", function()
+      nester.it("booleans", function()
+        local result <close> = inspector(true)
+        expect.equal(result, "true")
+
+        local result <close> = inspector(false)
+        expect.equal(result, "false")
+      end)
+
+      nester.it("integers", function()
+        local result <close> = inspector(10)
+        expect.equal(result, "10")
+      end)
+
+      nester.it("numbers", function()
+        local result <close> = inspector(20.20)
+        expect.equal(result, "20.2")
+
+        local result <close> = inspector(30_number)
+        expect.equal(result, "30.0")
+      end)
+
+      nester.it("strings", function()
+        local result <close> = inspector("hello world!")
+        expect.equal(result, "hello world!")
+
+        local result <close> = inspector("(cstring) hello world!"_cstring)
+        expect.equal(result, "(cstring) hello world!")
+      end)
+    end)
+  end)
+end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -57,10 +57,10 @@ nester.describe("inspector", function()
       }
 
       local result <close> = inspector(Weeks.Tuesday)
-      expect.equal(result, "Weeks.Tuesday --[[ = 2_i64 ]]")
+      expect.equal(result, "Weeks.Tuesday --[[ 2_i64 ]]")
 
       local result <close> = inspector(ByteWeeks.Friday)
-      expect.equal(result, "ByteWeeks.Friday --[[ = 5_u8 ]]")
+      expect.equal(result, "ByteWeeks.Friday --[[ 5_u8 ]]")
     end)
 
     nester.describe("arrays", function()

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -163,6 +163,39 @@ nester.describe("inspector", function()
           }, '\n')
         ]#)
       end)
+
+      nester.it("pointers", function()
+        local a: *int32 = (@*int32)(0x1234)
+
+        local result <close> = inspector(a)
+        expect.equal(result, '0x1234 --[[ @pointer(int32) ]]')
+
+        local RecOfPointers = @record{
+          a: *int32,
+          b: string,
+          c: *[2]integer,
+          d: [2]*integer,
+        }
+
+        local value: RecOfPointers = {
+          =a,
+          b = 'hello world!',
+          c = (@*[2]integer)(0x56789),
+          d = { (@*integer)(0x1010), (@*integer)(0x2020) },
+        }
+
+        local result <close> = inspector(value)
+        expect.equal(result, #[
+          table.concat({
+            '(@RecOfPointers){',
+            '  a = 0x1234 --[[ @pointer(int32) ]],',
+            '  b = "hello world!",',
+            '  c = 0x56789 --[[ @pointer(array(int64, 2)) ]],',
+            '  d = (@array(pointer(int64), 2)){ 0x1010 --[[ @pointer(int64) ]], 0x2020 --[[ @pointer(int64) ]] },',
+            '}'
+          }, '\n')
+        ]#)
+      end)
     end)
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -171,6 +171,13 @@ nester.describe("inspector", function()
         local result <close> = inspector(a)
         expect.equal(result, '0x1234 --[[ @pointer(int32) ]]')
 
+        local result  = inspector(nilptr)
+        expect.equal(result, 'nilptr')
+
+        local n: *int16 = nilptr
+        local result <close> = inspector(n)
+        expect.equal(result, 'nilptr --[[ @pointer(int16) ]]')
+
         local RecOfPointers = @record{
           a: *int32,
           b: string,

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -1,4 +1,4 @@
-require 'string' -- tostring
+require 'string'
 require 'inspector'
 require 'nester'
 
@@ -281,65 +281,92 @@ nester.describe("inspector", function()
           expect.equal(result, expected_str)
         end)
       end)
+    end)
 
-      nester.it("complex data-type", function()
-        local n: uint8 = 5
-        local E = @enum{ Foo = 0, Bar }
-        local function fn(i: integer): number return i + 1 end
+    nester.it("unions", function()
+      local MyRec1 = @record{ a: integer }
+      local MyRec2 = @record{ a: string }
 
-        local ComplexRec = @record{
-          a: int16,
-          b: record{ x: float32, y: boolean },
-          c: *uint8,
-          d: [2]int32,
-          e: E,
-          cb: function(i: integer): number,
-        }
+      local MyUnion = @union{
+        v1: MyRec1,
+        v2: MyRec2,
+      }
 
-        local value: [2]ComplexRec = {
-          {
-            a = 8,
-            b = { 10.25, true },
-            c = &n,
-            d = { 1, 2 },
-            e = E.Bar,
-            cb = fn
-          },
-          {}
-        }
+      local value: MyUnion = {v1 = {1} }
+      local result <close> = inspector(value)
+      expect.equal(result, '(@MyUnion)() --[[ @union{v1: MyRec1, v2: MyRec2} ]]')
 
+      local result <close> = inspector(value.v1)
+      expect.equal(result, #[
+        table.concat({
+          '(@MyRec1){',
+          '  a = 1_i64,',
+          '}',
+        }, '\n')
+      ]#)
+    end)
 
-        local result <close> = inspector(value)
-        local expected_str <close> = string.format(
-            #[
-            table.concat({
-              '(@array(ComplexRec, 2)){ {',
-              '  a = 8_i16,',
-              '  b = (@record{x: float32, y: boolean}){',
-              '    x = 10.25_f32,',
-              '    y = true,',
-              '  },',
-              '  c = %s --[[ @pointer(uint8) ]],',
-              '  d = (@array(int32, 2)){ 1, 2 },',
-              '  e = E.Bar --[[ 1_i64 ]],',
-              '  cb = %s --[[ function(i: int64): float64 ]],',
-              '}, {',
-              '  a = 0_i16,',
-              '  b = (@record{x: float32, y: boolean}){',
-              '    x = 0.0_f32,',
-              '    y = false,',
-              '  },',
-              '  c = nilptr --[[ @pointer(uint8) ]],',
-              '  d = (@array(int32, 2)){ 0, 0 },',
-              '  e = E.Foo --[[ 0_i64 ]],',
-              '  cb = nilptr --[[ function(i: int64): float64 ]],',
-              '} }'
-            }, '\n')
-          ]#,
-          &n, fn_hex_ptr(fn)
-        )
-        expect.equal(result, expected_str)
-      end)
+    nester.it("complex data-type", function()
+      local n: uint8 = 5
+      local E = @enum{ Foo = 0, Bar }
+      local U = @union{ n: uint8, e: E }
+      local function fn(i: integer): number return i + 1 end
+
+      local ComplexRec = @record{
+        a: int16,
+        b: record{ x: float32, y: boolean },
+        c: *uint8,
+        d: [2]int32,
+        e: E,
+        cb: function(i: integer): number,
+        u: U,
+      }
+
+      local value: [2]ComplexRec = {
+        {
+          a = 8,
+          b = { 10.25, true },
+          c = &n,
+          d = { 1, 2 },
+          e = E.Bar,
+          cb = fn,
+          u = { n = 1 }
+        },
+        {}
+      }
+
+      local result <close> = inspector(value)
+      local expected_str <close> = string.format(
+          #[
+          table.concat({
+            '(@array(ComplexRec, 2)){ {',
+            '  a = 8_i16,',
+            '  b = (@record{x: float32, y: boolean}){',
+            '    x = 10.25_f32,',
+            '    y = true,',
+            '  },',
+            '  c = %s --[[ @pointer(uint8) ]],',
+            '  d = (@array(int32, 2)){ 1, 2 },',
+            '  e = E.Bar --[[ 1_i64 ]],',
+            '  cb = %s --[[ function(i: int64): float64 ]],',
+            '  u = (@U)() --[[ @union{n: uint8, e: E} ]],',
+            '}, {',
+            '  a = 0_i16,',
+            '  b = (@record{x: float32, y: boolean}){',
+            '    x = 0.0_f32,',
+            '    y = false,',
+            '  },',
+            '  c = nilptr --[[ @pointer(uint8) ]],',
+            '  d = (@array(int32, 2)){ 0, 0 },',
+            '  e = E.Foo --[[ 0_i64 ]],',
+            '  cb = nilptr --[[ function(i: int64): float64 ]],',
+            '  u = (@U)() --[[ @union{n: uint8, e: E} ]],',
+            '} }'
+          }, '\n')
+        ]#,
+        &n, fn_hex_ptr(fn)
+      )
+      expect.equal(result, expected_str)
     end)
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -57,5 +57,33 @@ nester.describe("inspector", function()
         expect.equal(result, "(@array(float64, 2)){ -3.0, -2.0 }")
       end)
     end)
+
+    nester.it("enums", function()
+      local Weeks = @enum{
+        Sunday = 0,
+        Monday,
+        Tuesday,
+        Wednesday,
+        Thursday,
+        Friday,
+        Saturday
+      }
+
+      local ByteWeeks = @enum(byte){
+        Sunday = 0,
+        Monday,
+        Tuesday,
+        Wednesday,
+        Thursday,
+        Friday,
+        Saturday
+      }
+
+      local result <close> = inspector(Weeks.Tuesday)
+      expect.equal(result, "Weeks.Tuesday --[[ = 2_int64 ]]")
+
+      local result <close> = inspector(ByteWeeks.Friday)
+      expect.equal(result, "ByteWeeks.Friday --[[ = 5_uint8 ]]")
+    end)
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -14,15 +14,15 @@ nester.describe("inspector", function()
 
       nester.it("integers", function()
         local result <close> = inspector(10)
-        expect.equal(result, "10")
+        expect.equal(result, "10_i64")
       end)
 
       nester.it("numbers", function()
         local result <close> = inspector(20.20)
-        expect.equal(result, "20.2")
+        expect.equal(result, "20.2_f64")
 
         local result <close> = inspector(30_number)
-        expect.equal(result, "30.0")
+        expect.equal(result, "30.0_f64")
       end)
 
       nester.it("strings", function()
@@ -31,30 +31,6 @@ nester.describe("inspector", function()
 
         local result <close> = inspector("(cstring) hello world!"_cstring)
         expect.equal(result, "(cstring) hello world!")
-      end)
-    end)
-
-    nester.describe("arrays", function()
-      nester.it("boolean arrays", function()
-        local result <close> = inspector((@array(boolean, 3)){true, false, false})
-        expect.equal(result, "(@array(boolean, 3)){ true, false, false }")
-
-        -- using syntax sugar
-        local result <close> = inspector((@[2]boolean){false, true})
-        expect.equal(result, "(@array(boolean, 2)){ false, true }")
-      end)
-
-      nester.it("scalar arrays", function()
-        local result <close> = inspector((@array(uint16, 3)){3, 4, 5})
-        expect.equal(result, "(@array(uint16, 3)){ 3, 4, 5 }")
-
-        -- using syntax sugar
-        local result <close> = inspector((@[2]integer){1, 2})
-        expect.equal(result, "(@array(int64, 2)){ 1, 2 }")
-
-        -- inferred size
-        local result <close> = inspector((@[]number){-3, -2})
-        expect.equal(result, "(@array(float64, 2)){ -3.0, -2.0 }")
       end)
     end)
 
@@ -80,10 +56,35 @@ nester.describe("inspector", function()
       }
 
       local result <close> = inspector(Weeks.Tuesday)
-      expect.equal(result, "Weeks.Tuesday --[[ = 2_int64 ]]")
+      expect.equal(result, "Weeks.Tuesday --[[ = 2_i64 ]]")
 
       local result <close> = inspector(ByteWeeks.Friday)
-      expect.equal(result, "ByteWeeks.Friday --[[ = 5_uint8 ]]")
+      expect.equal(result, "ByteWeeks.Friday --[[ = 5_u8 ]]")
     end)
+
+    nester.describe("arrays", function()
+      nester.it("boolean arrays", function()
+        local result <close> = inspector((@array(boolean, 3)){true, false, false})
+        expect.equal(result, "(@array(boolean, 3)){ true, false, false }")
+
+        -- using syntax sugar
+        local result <close> = inspector((@[2]boolean){false, true})
+        expect.equal(result, "(@array(boolean, 2)){ false, true }")
+      end)
+
+      nester.it("scalar arrays", function()
+        local result <close> = inspector((@array(uint16, 3)){3, 4, 5})
+        expect.equal(result, "(@array(uint16, 3)){ 3_u16, 4_u16, 5_u16 }")
+
+        -- using syntax sugar
+        local result <close> = inspector((@[2]integer){1, 2})
+        expect.equal(result, "(@array(int64, 2)){ 1_i64, 2_i64 }")
+
+        -- inferred size
+        local result <close> = inspector((@[]number){-3, -2})
+        expect.equal(result, "(@array(float64, 2)){ -3.0_f64, -2.0_f64 }")
+      end)
+    end)
+
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -175,7 +175,7 @@ nester.describe("inspector", function()
       local result <close> = inspector(a)
       expect.equal(result, '0x1234 --[[ @pointer(int32) ]]')
 
-      local result  = inspector(nilptr)
+      local result <close> = inspector(nilptr)
       expect.equal(result, 'nilptr')
 
       local n: *int16 = nilptr

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -206,6 +206,11 @@ nester.describe("inspector", function()
       end)
 
       nester.describe("functions", function()
+        local function fn_hex_ptr(callback: auto)
+          local cb_str <close> = tostring(callback)
+          return cb_str:gsub('function: ', '', 1)
+        end
+
         local function foo(a: integer, b: integer): integer
           return a + b
         end
@@ -248,11 +253,9 @@ nester.describe("inspector", function()
           cb.callback_add = foo
           cb.callback_print = bar
 
-          local a_str <close> = tostring(cb.callback_add):gsub('function: ', '', 1)
-          local p_str <close> = tostring(cb.callback_print):gsub('function: ', '', 1)
-
-          local result <close> = inspector(cb)
-          expect.equal(result, string.format(
+          local a_str <close> = fn_hex_ptr(cb.callback_add)
+          local p_str <close> = fn_hex_ptr(cb.callback_print)
+          local expected_str <close> = string.format(
             #[
               table.concat({
                 '(@Callbacks){',
@@ -263,15 +266,19 @@ nester.describe("inspector", function()
             ]#,
             a_str,
             p_str
-          ))
+          )
+
+          local result <close> = inspector(cb)
+          expect.equal(result, expected_str)
         end)
 
         nester.it("array of callbacks", function()
           local arr: [2]function(string) = { bar, bar }
-          local bar_s <close> = tostring(bar):gsub('function: ', '', 1)
+          local bar_s <close> = fn_hex_ptr(bar)
 
           local result <close> = inspector(arr)
-          expect.equal(result, string.format('(@array(function(string): void, 2)){ %s, %s }', bar_s, bar_s ))
+          local expected_str <close> = string.format('(@array(function(string): void, 2)){ %s, %s }', bar_s, bar_s )
+          expect.equal(result, expected_str)
         end)
       end)
     end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -1,3 +1,4 @@
+require 'string' -- tostring
 require 'inspector'
 require 'nester'
 
@@ -195,6 +196,76 @@ nester.describe("inspector", function()
             '}'
           }, '\n')
         ]#)
+      end)
+
+      nester.describe("functions", function()
+        local function foo(a: integer, b: integer): integer
+          return a + b
+        end
+
+        local function bar(s: string)
+          print(s)
+        end
+
+        local function tos(v: auto): string
+          return tostring(v)
+        end
+
+        nester.it("simple", function()
+          local result <close> = inspector(foo)
+          expect.equal(result, 'function(a: int64, b: int64): int64')
+        end)
+
+        nester.it("polymorphic", function()
+          local result <close> = inspector(tos)
+          expect.equal(result, 'polyfunction(v: auto): string')
+        end)
+
+        nester.it("record of callbacks", function()
+          local Callbacks = @record{
+            callback_add: function(a: integer, b: integer): integer,
+            callback_print: function(string),
+          }
+          local cb: Callbacks = {}
+
+          local result <close> = inspector(cb)
+          expect.equal(result, #[
+            table.concat({
+              '(@Callbacks){',
+              '  callback_add = nilptr --[[ function(a: int64, b: int64): int64 ]],',
+              '  callback_print = nilptr --[[ function(string): void ]],',
+              '}'
+            }, '\n')
+          ]#)
+
+          cb.callback_add = foo
+          cb.callback_print = bar
+
+          local a_str <close> = tostring(cb.callback_add):gsub('function: ', '', 1)
+          local p_str <close> = tostring(cb.callback_print):gsub('function: ', '', 1)
+
+          local result <close> = inspector(cb)
+          expect.equal(result, string.format(
+            #[
+              table.concat({
+                '(@Callbacks){',
+                '  callback_add = %s --[[ function(a: int64, b: int64): int64 ]],',
+                '  callback_print = %s --[[ function(string): void ]],',
+                '}'
+              }, '\n')
+            ]#,
+            a_str,
+            p_str
+          ))
+        end)
+
+        nester.it("array of callbacks", function()
+          local arr: [2]function(string) = { bar, bar }
+          local bar_s <close> = tostring(bar):gsub('function: ', '', 1)
+
+          local result <close> = inspector(arr)
+          expect.equal(result, string.format('(@array(function(string): void, 2)){ %s, %s }', bar_s, bar_s ))
+        end)
       end)
     end)
   end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -74,15 +74,15 @@ nester.describe("inspector", function()
 
       nester.it("scalar arrays", function()
         local result <close> = inspector((@array(uint16, 3)){3, 4, 5})
-        expect.equal(result, "(@array(uint16, 3)){ 3_u16, 4_u16, 5_u16 }")
+        expect.equal(result, "(@array(uint16, 3)){ 3, 4, 5 }")
 
         -- using syntax sugar
         local result <close> = inspector((@[2]integer){1, 2})
-        expect.equal(result, "(@array(int64, 2)){ 1_i64, 2_i64 }")
+        expect.equal(result, "(@array(int64, 2)){ 1, 2 }")
 
         -- inferred size
         local result <close> = inspector((@[]number){-3, -2})
-        expect.equal(result, "(@array(float64, 2)){ -3.0_f64, -2.0_f64 }")
+        expect.equal(result, "(@array(float64, 2)){ -3.0, -2.0 }")
       end)
     end)
 
@@ -100,6 +100,66 @@ nester.describe("inspector", function()
             '  a = 10_i64,',
             '  b = 20.2_f64,' ,
             '}'
+          }, '\n')
+        ]#)
+
+        local SimpleArrRec = @record{
+          a: [3]integer,
+        }
+
+        local result <close> = inspector((@SimpleArrRec){ a = { 1, 2, 3 } })
+        expect.equal(result, #[
+          table.concat({
+            '(@SimpleArrRec){',
+            '  a = (@array(int64, 3)){ 1, 2, 3 },',
+            '}'
+          }, '\n')
+        ]#)
+      end)
+
+      nester.it("nested records", function()
+        local InnerRecord = @record{
+          a: integer,
+        }
+
+        local OuterRecord = @record{
+          ir: InnerRecord,
+          b: [2]integer
+        }
+
+        local result <close> = inspector((@OuterRecord){ ir = { a = 10 }, b = {20, 30} })
+        expect.equal(result, #[
+          table.concat({
+            '(@OuterRecord){',
+            '  ir = (@InnerRecord){',
+            '    a = 10_i64,',
+            '  },',
+            '  b = (@array(int64, 2)){ 20, 30 },',
+            '}'
+          }, '\n')
+        ]#)
+      end)
+
+      nester.it("record arrays", function()
+        local MyRec = @record{
+          b: byte,
+          i: int16
+        }
+
+        local result <close> = inspector((@[2]MyRec){
+          { b = 1, i = 10},
+          { b = 2, i = 20},
+        })
+
+        expect.equal(result, #[
+          table.concat({
+            '(@array(MyRec, 2)){ {',
+            '  b = 1_u8,',
+            '  i = 10_i16,',
+            '}, {',
+            '  b = 2_u8,',
+            '  i = 20_i16,',
+            '} }',
           }, '\n')
         ]#)
       end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -27,10 +27,10 @@ nester.describe("inspector", function()
 
       nester.it("strings", function()
         local result <close> = inspector("hello world!")
-        expect.equal(result, "hello world!")
+        expect.equal(result, '"hello world!"')
 
-        local result <close> = inspector("(cstring) hello world!"_cstring)
-        expect.equal(result, "(cstring) hello world!")
+        local result <close> = inspector("hello world!"_cstring)
+        expect.equal(result, '"hello world!" --[[ @cstring ]]')
       end)
     end)
 

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -86,5 +86,23 @@ nester.describe("inspector", function()
       end)
     end)
 
+    nester.describe("records", function()
+      nester.it("simple", function()
+        local SimpleRec = @record{
+          a: integer,
+          b: number
+        }
+
+        local result <close> = inspector((@SimpleRec){ 10, 20.20 })
+        expect.equal(result, #[
+          table.concat({
+            '(@SimpleRec){',
+            '  a = 10_i64,',
+            '  b = 20.2_f64,' ,
+            '}'
+          }, '\n')
+        ]#)
+      end)
+    end)
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -8,365 +8,390 @@ local function fn_hex_ptr(callback: auto)
 end
 
 nester.describe("inspector", function()
-  nester.describe("primitives", function()
-    nester.describe("simple", function()
-      nester.it("booleans", function()
-        local result <close> = inspector(true)
-        expect.equal(result, "true")
+  nester.describe("simple", function()
+    nester.it("booleans", function()
+      local result <close> = inspector(true)
+      expect.equal(result, "true")
 
-        local result <close> = inspector(false)
-        expect.equal(result, "false")
-      end)
-
-      nester.it("integers", function()
-        local result <close> = inspector(10)
-        expect.equal(result, "10_i64")
-      end)
-
-      nester.it("numbers", function()
-        local result <close> = inspector(20.20)
-        expect.equal(result, "20.2_f64")
-
-        local result <close> = inspector(30_number)
-        expect.equal(result, "30.0_f64")
-      end)
-
-      nester.it("strings", function()
-        local result <close> = inspector("hello world!")
-        expect.equal(result, '"hello world!"')
-
-        local result <close> = inspector("hello world!"_cstring)
-        expect.equal(result, '"hello world!" --[[ @cstring ]]')
-      end)
+      local result <close> = inspector(false)
+      expect.equal(result, "false")
     end)
 
-    nester.it("enums", function()
-      local Weeks = @enum{
-        Sunday = 0,
-        Monday,
-        Tuesday,
-        Wednesday,
-        Thursday,
-        Friday,
-        Saturday
+    nester.it("integers", function()
+      local result <close> = inspector(10)
+      expect.equal(result, "10_i64")
+    end)
+
+    nester.it("numbers", function()
+      local result <close> = inspector(20.20)
+      expect.equal(result, "20.2_f64")
+
+      local result <close> = inspector(30_number)
+      expect.equal(result, "30.0_f64")
+    end)
+
+    nester.it("strings", function()
+      local result <close> = inspector("hello world!")
+      expect.equal(result, '"hello world!"')
+
+      local result <close> = inspector("hello world!"_cstring)
+      expect.equal(result, '"hello world!" --[[ @cstring ]]')
+    end)
+  end)
+
+  nester.it("enums", function()
+    local Weeks = @enum{
+      Sunday = 0,
+      Monday,
+      Tuesday,
+      Wednesday,
+      Thursday,
+      Friday,
+      Saturday
+    }
+
+    local ByteWeeks = @enum(byte){
+      Sunday = 0,
+      Monday,
+      Tuesday,
+      Wednesday,
+      Thursday,
+      Friday,
+      Saturday
+    }
+
+    local result <close> = inspector(Weeks.Tuesday)
+    expect.equal(result, "Weeks.Tuesday --[[ 2_i64 ]]")
+
+    local result <close> = inspector(ByteWeeks.Friday)
+    expect.equal(result, "ByteWeeks.Friday --[[ 5_u8 ]]")
+  end)
+
+  nester.describe("arrays", function()
+    nester.it("boolean arrays", function()
+      local result <close> = inspector((@array(boolean, 3)){true, false, false})
+      expect.equal(result, "(@array(boolean, 3)){ true, false, false }")
+
+      -- using syntax sugar
+      local result <close> = inspector((@[2]boolean){false, true})
+      expect.equal(result, "(@array(boolean, 2)){ false, true }")
+    end)
+
+    nester.it("scalar arrays", function()
+      local result <close> = inspector((@array(uint16, 3)){3, 4, 5})
+      expect.equal(result, "(@array(uint16, 3)){ 3, 4, 5 }")
+
+      -- using syntax sugar
+      local result <close> = inspector((@[2]integer){1, 2})
+      expect.equal(result, "(@array(int64, 2)){ 1, 2 }")
+
+      -- inferred size
+      local result <close> = inspector((@[]number){-3, -2})
+      expect.equal(result, "(@array(float64, 2)){ -3.0, -2.0 }")
+    end)
+  end)
+
+  nester.describe("records", function()
+    nester.it("simple", function()
+      local SimpleRec = @record{
+        a: integer,
+        b: number
       }
 
-      local ByteWeeks = @enum(byte){
-        Sunday = 0,
-        Monday,
-        Tuesday,
-        Wednesday,
-        Thursday,
-        Friday,
-        Saturday
-      }
-
-      local result <close> = inspector(Weeks.Tuesday)
-      expect.equal(result, "Weeks.Tuesday --[[ 2_i64 ]]")
-
-      local result <close> = inspector(ByteWeeks.Friday)
-      expect.equal(result, "ByteWeeks.Friday --[[ 5_u8 ]]")
-    end)
-
-    nester.describe("arrays", function()
-      nester.it("boolean arrays", function()
-        local result <close> = inspector((@array(boolean, 3)){true, false, false})
-        expect.equal(result, "(@array(boolean, 3)){ true, false, false }")
-
-        -- using syntax sugar
-        local result <close> = inspector((@[2]boolean){false, true})
-        expect.equal(result, "(@array(boolean, 2)){ false, true }")
-      end)
-
-      nester.it("scalar arrays", function()
-        local result <close> = inspector((@array(uint16, 3)){3, 4, 5})
-        expect.equal(result, "(@array(uint16, 3)){ 3, 4, 5 }")
-
-        -- using syntax sugar
-        local result <close> = inspector((@[2]integer){1, 2})
-        expect.equal(result, "(@array(int64, 2)){ 1, 2 }")
-
-        -- inferred size
-        local result <close> = inspector((@[]number){-3, -2})
-        expect.equal(result, "(@array(float64, 2)){ -3.0, -2.0 }")
-      end)
-    end)
-
-    nester.describe("records", function()
-      nester.it("simple", function()
-        local SimpleRec = @record{
-          a: integer,
-          b: number
-        }
-
-        local result <close> = inspector((@SimpleRec){ 10, 20.20 })
-        expect.equal(result, #[
-          table.concat({
-            '(@SimpleRec){',
-            '  a = 10_i64,',
-            '  b = 20.2_f64,' ,
-            '}'
-          }, '\n')
-        ]#)
-
-        local SimpleArrRec = @record{
-          a: [3]integer,
-        }
-
-        local result <close> = inspector((@SimpleArrRec){ a = { 1, 2, 3 } })
-        expect.equal(result, #[
-          table.concat({
-            '(@SimpleArrRec){',
-            '  a = (@array(int64, 3)){ 1, 2, 3 },',
-            '}'
-          }, '\n')
-        ]#)
-      end)
-
-      nester.it("nested records", function()
-        local InnerRecord = @record{
-          a: integer,
-        }
-
-        local OuterRecord = @record{
-          ir: InnerRecord,
-          b: [2]integer
-        }
-
-        local result <close> = inspector((@OuterRecord){ ir = { a = 10 }, b = {20, 30} })
-        expect.equal(result, #[
-          table.concat({
-            '(@OuterRecord){',
-            '  ir = (@InnerRecord){',
-            '    a = 10_i64,',
-            '  },',
-            '  b = (@array(int64, 2)){ 20, 30 },',
-            '}'
-          }, '\n')
-        ]#)
-      end)
-
-      nester.it("record arrays", function()
-        local MyRec = @record{
-          b: byte,
-          i: int16
-        }
-
-        local result <close> = inspector((@[2]MyRec){
-          { b = 1, i = 10},
-          { b = 2, i = 20},
-        })
-
-        expect.equal(result, #[
-          table.concat({
-            '(@array(MyRec, 2)){ {',
-            '  b = 1_u8,',
-            '  i = 10_i16,',
-            '}, {',
-            '  b = 2_u8,',
-            '  i = 20_i16,',
-            '} }',
-          }, '\n')
-        ]#)
-      end)
-
-      nester.it("pointers", function()
-        local a: *int32 = (@*int32)(0x1234)
-
-        local result <close> = inspector(a)
-        expect.equal(result, '0x1234 --[[ @pointer(int32) ]]')
-
-        local result  = inspector(nilptr)
-        expect.equal(result, 'nilptr')
-
-        local n: *int16 = nilptr
-        local result <close> = inspector(n)
-        expect.equal(result, 'nilptr --[[ @pointer(int16) ]]')
-
-        local RecOfPointers = @record{
-          a: *int32,
-          b: string,
-          c: *[2]integer,
-          d: [2]*integer,
-        }
-
-        local value: RecOfPointers = {
-          =a,
-          b = 'hello world!',
-          c = (@*[2]integer)(0x56789),
-          d = { (@*integer)(0x1010), (@*integer)(0x2020) },
-        }
-
-        local result <close> = inspector(value)
-        expect.equal(result, #[
-          table.concat({
-            '(@RecOfPointers){',
-            '  a = 0x1234 --[[ @pointer(int32) ]],',
-            '  b = "hello world!",',
-            '  c = 0x56789 --[[ @pointer(array(int64, 2)) ]],',
-            '  d = (@array(pointer(int64), 2)){ 0x1010 --[[ @pointer(int64) ]], 0x2020 --[[ @pointer(int64) ]] },',
-            '}'
-          }, '\n')
-        ]#)
-      end)
-
-      nester.describe("functions", function()
-        local function foo(a: integer, b: integer): integer
-          return a + b
-        end
-
-        local function bar(s: string)
-          print(s)
-        end
-
-        local function tos(v: auto): string
-          return tostring(v)
-        end
-
-        nester.it("simple", function()
-          local result <close> = inspector(foo)
-          expect.equal(result, 'function(a: int64, b: int64): int64')
-        end)
-
-        nester.it("polymorphic", function()
-          local result <close> = inspector(tos)
-          expect.equal(result, 'polyfunction(v: auto): string')
-        end)
-
-        nester.it("record of callbacks", function()
-          local Callbacks = @record{
-            callback_add: function(a: integer, b: integer): integer,
-            callback_print: function(string),
-          }
-          local cb: Callbacks = {}
-
-          local result <close> = inspector(cb)
-          expect.equal(result, #[
-            table.concat({
-              '(@Callbacks){',
-              '  callback_add = nilptr --[[ function(a: int64, b: int64): int64 ]],',
-              '  callback_print = nilptr --[[ function(string): void ]],',
-              '}'
-            }, '\n')
-          ]#)
-
-          cb.callback_add = foo
-          cb.callback_print = bar
-
-          local a_str <close> = fn_hex_ptr(cb.callback_add)
-          local p_str <close> = fn_hex_ptr(cb.callback_print)
-          local expected_str <close> = string.format(
-            #[
-              table.concat({
-                '(@Callbacks){',
-                '  callback_add = %s --[[ function(a: int64, b: int64): int64 ]],',
-                '  callback_print = %s --[[ function(string): void ]],',
-                '}'
-              }, '\n')
-            ]#,
-            a_str,
-            p_str
-          )
-
-          local result <close> = inspector(cb)
-          expect.equal(result, expected_str)
-        end)
-
-        nester.it("array of callbacks", function()
-          local arr: [2]function(string) = { bar, bar }
-          local bar_s <close> = fn_hex_ptr(bar)
-
-          local result <close> = inspector(arr)
-          local expected_str <close> = string.format('(@array(function(string): void, 2)){ %s, %s }', bar_s, bar_s )
-          expect.equal(result, expected_str)
-        end)
-      end)
-    end)
-
-    nester.it("unions", function()
-      local MyRec1 = @record{ a: integer }
-      local MyRec2 = @record{ a: string }
-
-      local MyUnion = @union{
-        v1: MyRec1,
-        v2: MyRec2,
-      }
-
-      local value: MyUnion = {v1 = {1} }
-      local result <close> = inspector(value)
-      expect.equal(result, '(@MyUnion)() --[[ @union{v1: MyRec1, v2: MyRec2} ]]')
-
-      local result <close> = inspector(value.v1)
+      local result <close> = inspector((@SimpleRec){ 10, 20.20 })
       expect.equal(result, #[
         table.concat({
-          '(@MyRec1){',
-          '  a = 1_i64,',
-          '}',
+          '(@SimpleRec){',
+          '  a = 10_i64,',
+          '  b = 20.2_f64,' ,
+          '}'
+        }, '\n')
+      ]#)
+
+      local SimpleArrRec = @record{
+        a: [3]integer,
+      }
+
+      local result <close> = inspector((@SimpleArrRec){ a = { 1, 2, 3 } })
+      expect.equal(result, #[
+        table.concat({
+          '(@SimpleArrRec){',
+          '  a = (@array(int64, 3)){ 1, 2, 3 },',
+          '}'
         }, '\n')
       ]#)
     end)
 
-    nester.it("complex data-type", function()
-      local n: uint8 = 5
-      local E = @enum{ Foo = 0, Bar }
-      local U = @union{ n: uint8, e: E }
-      local function fn(i: integer): number return i + 1 end
-
-      local ComplexRec = @record{
-        a: int16,
-        b: record{ x: float32, y: boolean },
-        c: *uint8,
-        d: [2]int32,
-        e: E,
-        cb: function(i: integer): number,
-        u: U,
+    nester.it("nested records", function()
+      local InnerRecord = @record{
+        a: integer,
       }
 
-      local value: [2]ComplexRec = {
-        {
-          a = 8,
-          b = { 10.25, true },
-          c = &n,
-          d = { 1, 2 },
-          e = E.Bar,
-          cb = fn,
-          u = { n = 1 }
-        },
-        {}
+      local OuterRecord = @record{
+        ir: InnerRecord,
+        b: [2]integer
+      }
+
+      local result <close> = inspector((@OuterRecord){ ir = { a = 10 }, b = {20, 30} })
+      expect.equal(result, #[
+        table.concat({
+          '(@OuterRecord){',
+          '  ir = (@InnerRecord){',
+          '    a = 10_i64,',
+          '  },',
+          '  b = (@array(int64, 2)){ 20, 30 },',
+          '}'
+        }, '\n')
+      ]#)
+    end)
+
+    nester.it("record arrays", function()
+      local MyRec = @record{
+        b: byte,
+        i: int16
+      }
+
+      local result <close> = inspector((@[2]MyRec){
+        { b = 1, i = 10},
+        { b = 2, i = 20},
+      })
+
+      expect.equal(result, #[
+        table.concat({
+          '(@array(MyRec, 2)){ {',
+          '  b = 1_u8,',
+          '  i = 10_i16,',
+          '}, {',
+          '  b = 2_u8,',
+          '  i = 20_i16,',
+          '} }',
+        }, '\n')
+      ]#)
+    end)
+
+    nester.it("pointers", function()
+      local a: *int32 = (@*int32)(0x1234)
+
+      local result <close> = inspector(a)
+      expect.equal(result, '0x1234 --[[ @pointer(int32) ]]')
+
+      local result  = inspector(nilptr)
+      expect.equal(result, 'nilptr')
+
+      local n: *int16 = nilptr
+      local result <close> = inspector(n)
+      expect.equal(result, 'nilptr --[[ @pointer(int16) ]]')
+
+      local RecOfPointers = @record{
+        a: *int32,
+        b: string,
+        c: *[2]integer,
+        d: [2]*integer,
+      }
+
+      local value: RecOfPointers = {
+        =a,
+        b = 'hello world!',
+        c = (@*[2]integer)(0x56789),
+        d = { (@*integer)(0x1010), (@*integer)(0x2020) },
       }
 
       local result <close> = inspector(value)
+      expect.equal(result, #[
+        table.concat({
+          '(@RecOfPointers){',
+          '  a = 0x1234 --[[ @pointer(int32) ]],',
+          '  b = "hello world!",',
+          '  c = 0x56789 --[[ @pointer(array(int64, 2)) ]],',
+          '  d = (@array(pointer(int64), 2)){ 0x1010 --[[ @pointer(int64) ]], 0x2020 --[[ @pointer(int64) ]] },',
+          '}'
+        }, '\n')
+      ]#)
+    end)
+  end)
+
+  nester.describe("functions", function()
+    local function foo(a: integer, b: integer): integer
+      return a + b
+    end
+
+    local function bar(s: string)
+      print(s)
+    end
+
+    local function tos(v: auto): string
+      return tostring(v)
+    end
+
+    nester.it("simple", function()
+      local result <close> = inspector(foo)
+      expect.equal(result, 'function(a: int64, b: int64): int64')
+    end)
+
+    nester.it("polymorphic", function()
+      local result <close> = inspector(tos)
+      expect.equal(result, 'polyfunction(v: auto): string')
+    end)
+
+    nester.it("record of callbacks", function()
+      local Callbacks = @record{
+        callback_add: function(a: integer, b: integer): integer,
+        callback_print: function(string),
+      }
+      local cb: Callbacks = {}
+
+      local result <close> = inspector(cb)
+      expect.equal(result, #[
+        table.concat({
+          '(@Callbacks){',
+          '  callback_add = nilptr --[[ function(a: int64, b: int64): int64 ]],',
+          '  callback_print = nilptr --[[ function(string): void ]],',
+          '}'
+        }, '\n')
+      ]#)
+
+      cb.callback_add = foo
+      cb.callback_print = bar
+
+      local a_str <close> = fn_hex_ptr(cb.callback_add)
+      local p_str <close> = fn_hex_ptr(cb.callback_print)
       local expected_str <close> = string.format(
-          #[
+        #[
           table.concat({
-            '(@array(ComplexRec, 2)){ {',
-            '  a = 8_i16,',
-            '  b = (@record{x: float32, y: boolean}){',
-            '    x = 10.25_f32,',
-            '    y = true,',
-            '  },',
-            '  c = %s --[[ @pointer(uint8) ]],',
-            '  d = (@array(int32, 2)){ 1, 2 },',
-            '  e = E.Bar --[[ 1_i64 ]],',
-            '  cb = %s --[[ function(i: int64): float64 ]],',
-            '  u = (@U)() --[[ @union{n: uint8, e: E} ]],',
-            '}, {',
-            '  a = 0_i16,',
-            '  b = (@record{x: float32, y: boolean}){',
-            '    x = 0.0_f32,',
-            '    y = false,',
-            '  },',
-            '  c = nilptr --[[ @pointer(uint8) ]],',
-            '  d = (@array(int32, 2)){ 0, 0 },',
-            '  e = E.Foo --[[ 0_i64 ]],',
-            '  cb = nilptr --[[ function(i: int64): float64 ]],',
-            '  u = (@U)() --[[ @union{n: uint8, e: E} ]],',
-            '} }'
+            '(@Callbacks){',
+            '  callback_add = %s --[[ function(a: int64, b: int64): int64 ]],',
+            '  callback_print = %s --[[ function(string): void ]],',
+            '}'
           }, '\n')
         ]#,
-        &n, fn_hex_ptr(fn)
+        a_str,
+        p_str
       )
+
+      local result <close> = inspector(cb)
       expect.equal(result, expected_str)
     end)
+
+    nester.it("array of callbacks", function()
+      local arr: [2]function(string) = { bar, bar }
+      local bar_s <close> = fn_hex_ptr(bar)
+
+      local result <close> = inspector(arr)
+      local expected_str <close> = string.format('(@array(function(string): void, 2)){ %s, %s }', bar_s, bar_s )
+      expect.equal(result, expected_str)
+    end)
+  end)
+
+  nester.it("unions", function()
+    local MyRec1 = @record{ a: integer }
+    local MyRec2 = @record{ a: string }
+
+    local MyUnion = @union{
+      v1: MyRec1,
+      v2: MyRec2,
+    }
+
+    local value: MyUnion = {v1 = {1} }
+    local result <close> = inspector(value)
+    expect.equal(result, '(@MyUnion)() --[[ @union{v1: MyRec1, v2: MyRec2} ]]')
+
+    local result <close> = inspector(value.v1)
+    expect.equal(result, #[
+      table.concat({
+        '(@MyRec1){',
+        '  a = 1_i64,',
+        '}',
+      }, '\n')
+    ]#)
+  end)
+
+  nester.describe("types (typedesc)", function()
+    local MyRec = @record{ b: byte }
+    local MyUnion = @union{ n: integer, m: MyRec }
+    local MyEnum = @enum{ Foo = 0, Bar }
+    local MyArr = @array(MyEnum, 2)
+
+    nester.it('record', function()
+      local result <close> = inspector(MyRec)
+      expect.equal(result, '@record{b: uint8}')
+    end)
+
+    nester.it('union', function()
+      local result <close> = inspector(MyUnion)
+      expect.equal(result, '@union{n: int64, m: MyRec}')
+    end)
+
+    nester.it('enum', function()
+      local result <close> = inspector(MyEnum)
+      expect.equal(result, '@enum(int64){Foo=0, Bar=1}')
+    end)
+
+    nester.it('array', function()
+      local result <close> = inspector(MyArr)
+      expect.equal(result, '@array(MyEnum, 2)')
+    end)
+  end)
+
+  nester.it("complex data-type", function()
+    local n: uint8 = 5
+    local E = @enum{ Foo = 0, Bar }
+    local U = @union{ n: uint8, e: E }
+    local function fn(i: integer): number return i + 1 end
+
+    local ComplexRec = @record{
+      a: int16,
+      b: record{ x: float32, y: boolean },
+      c: *uint8,
+      d: [2]int32,
+      e: E,
+      cb: function(i: integer): number,
+      u: U,
+    }
+
+    local value: [2]ComplexRec = {
+      {
+        a = 8,
+        b = { 10.25, true },
+        c = &n,
+        d = { 1, 2 },
+        e = E.Bar,
+        cb = fn,
+        u = { n = 1 }
+      },
+      {}
+    }
+
+    local result <close> = inspector(value)
+    local expected_str <close> = string.format(
+        #[
+        table.concat({
+          '(@array(ComplexRec, 2)){ {',
+          '  a = 8_i16,',
+          '  b = (@record{x: float32, y: boolean}){',
+          '    x = 10.25_f32,',
+          '    y = true,',
+          '  },',
+          '  c = %s --[[ @pointer(uint8) ]],',
+          '  d = (@array(int32, 2)){ 1, 2 },',
+          '  e = E.Bar --[[ 1_i64 ]],',
+          '  cb = %s --[[ function(i: int64): float64 ]],',
+          '  u = (@U)() --[[ @union{n: uint8, e: E} ]],',
+          '}, {',
+          '  a = 0_i16,',
+          '  b = (@record{x: float32, y: boolean}){',
+          '    x = 0.0_f32,',
+          '    y = false,',
+          '  },',
+          '  c = nilptr --[[ @pointer(uint8) ]],',
+          '  d = (@array(int32, 2)){ 0, 0 },',
+          '  e = E.Foo --[[ 0_i64 ]],',
+          '  cb = nilptr --[[ function(i: int64): float64 ]],',
+          '  u = (@U)() --[[ @union{n: uint8, e: E} ]],',
+          '} }'
+        }, '\n')
+      ]#,
+      &n, fn_hex_ptr(fn)
+    )
+    expect.equal(result, expected_str)
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -33,5 +33,29 @@ nester.describe("inspector", function()
         expect.equal(result, "(cstring) hello world!")
       end)
     end)
+
+    nester.describe("arrays", function()
+      nester.it("boolean arrays", function()
+        local result <close> = inspector((@array(boolean, 3)){true, false, false})
+        expect.equal(result, "(@array(boolean, 3)){ true, false, false }")
+
+        -- using syntax sugar
+        local result <close> = inspector((@[2]boolean){false, true})
+        expect.equal(result, "(@array(boolean, 2)){ false, true }")
+      end)
+
+      nester.it("scalar arrays", function()
+        local result <close> = inspector((@array(uint16, 3)){3, 4, 5})
+        expect.equal(result, "(@array(uint16, 3)){ 3, 4, 5 }")
+
+        -- using syntax sugar
+        local result <close> = inspector((@[2]integer){1, 2})
+        expect.equal(result, "(@array(int64, 2)){ 1, 2 }")
+
+        -- inferred size
+        local result <close> = inspector((@[]number){-3, -2})
+        expect.equal(result, "(@array(float64, 2)){ -3.0, -2.0 }")
+      end)
+    end)
   end)
 end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -2,6 +2,11 @@ require 'string' -- tostring
 require 'inspector'
 require 'nester'
 
+local function fn_hex_ptr(callback: auto)
+  local cb_str <close> = tostring(callback)
+  return cb_str:gsub('function: ', '', 1)
+end
+
 nester.describe("inspector", function()
   nester.describe("primitives", function()
     nester.describe("simple", function()
@@ -206,11 +211,6 @@ nester.describe("inspector", function()
       end)
 
       nester.describe("functions", function()
-        local function fn_hex_ptr(callback: auto)
-          local cb_str <close> = tostring(callback)
-          return cb_str:gsub('function: ', '', 1)
-        end
-
         local function foo(a: integer, b: integer): integer
           return a + b
         end
@@ -280,6 +280,65 @@ nester.describe("inspector", function()
           local expected_str <close> = string.format('(@array(function(string): void, 2)){ %s, %s }', bar_s, bar_s )
           expect.equal(result, expected_str)
         end)
+      end)
+
+      nester.it("complex data-type", function()
+        local n: uint8 = 5
+        local E = @enum{ Foo = 0, Bar }
+        local function fn(i: integer): number return i + 1 end
+
+        local ComplexRec = @record{
+          a: int16,
+          b: record{ x: float32, y: boolean },
+          c: *uint8,
+          d: [2]int32,
+          e: E,
+          cb: function(i: integer): number,
+        }
+
+        local value: [2]ComplexRec = {
+          {
+            a = 8,
+            b = { 10.25, true },
+            c = &n,
+            d = { 1, 2 },
+            e = E.Bar,
+            cb = fn
+          },
+          {}
+        }
+
+
+        local result <close> = inspector(value)
+        local expected_str <close> = string.format(
+            #[
+            table.concat({
+              '(@array(ComplexRec, 2)){ {',
+              '  a = 8_i16,',
+              '  b = (@record{x: float32, y: boolean}){',
+              '    x = 10.25_f32,',
+              '    y = true,',
+              '  },',
+              '  c = %s --[[ @pointer(uint8) ]],',
+              '  d = (@array(int32, 2)){ 1, 2 },',
+              '  e = E.Bar --[[ 1_i64 ]],',
+              '  cb = %s --[[ function(i: int64): float64 ]],',
+              '}, {',
+              '  a = 0_i16,',
+              '  b = (@record{x: float32, y: boolean}){',
+              '    x = 0.0_f32,',
+              '    y = false,',
+              '  },',
+              '  c = nilptr --[[ @pointer(uint8) ]],',
+              '  d = (@array(int32, 2)){ 0, 0 },',
+              '  e = E.Foo --[[ 0_i64 ]],',
+              '  cb = nilptr --[[ function(i: int64): float64 ]],',
+              '} }'
+            }, '\n')
+          ]#,
+          &n, fn_hex_ptr(fn)
+        )
+        expect.equal(result, expected_str)
       end)
     end)
   end)

--- a/tests/inspector_test.nelua
+++ b/tests/inspector_test.nelua
@@ -361,6 +361,8 @@ nester.describe("inspector", function()
       {}
     }
 
+    local fn_hex <close> = fn_hex_ptr(fn)
+
     local result <close> = inspector(value)
     local expected_str <close> = string.format(
         #[
@@ -390,7 +392,7 @@ nester.describe("inspector", function()
           '} }'
         }, '\n')
       ]#,
-      &n, fn_hex_ptr(fn)
+      &n, fn_hex
     )
     expect.equal(result, expected_str)
   end)


### PR DESCRIPTION
This library it's inspired the [inspect.lua](https://github.com/kikito/inspect.lua/).

Just as inspect, just call the function and it'll return a string with the contents, it also makes it best to show the types of the values and avoids redundancy.

```lua
require 'inspector'

local vec2 = @record{
  x: number,
  y: number
}

local position: vec2 = { 2, 3 }

local pos_contents <close> = inspector(position)
print(pos_contents)

--[[ output:
(@vec2){
  x = 2.0_f64,
  y = 3.0_f64,
}
]]

local positions: [2]vec2 = { {1, 2}, {8, 9} }

local positions_s <close> = inspector(positions)
print(positions_s)

--[[ output:
(@array(vec2, 2)){ {
  x = 1.0_f64,
  y = 2.0_f64,
}, {
  x = 8.0_f64,
  y = 9.0_f64,
} }
]]


local numbers: [2]byte = { 2, 4 }

local numbers_s <close> = inspector(numbers)
print(numbers_s)

-- output: (@array(uint8, 2)){ 2, 4 }
```

All the tests passes and `--sanitize` shows no problems, the only data-type which the content isn't really inspected it's `union`, since it's not possible to know which field should be inspected.